### PR TITLE
"Install" option in openiBoot/utils/oibc/Makefile

### DIFF
--- a/utils/oibc/Makefile
+++ b/utils/oibc/Makefile
@@ -25,3 +25,5 @@ clean:
 	-rm oibc
 	-rm loadibec
 
+install:
+	install -m +x oibc /usr/bin/


### PR DESCRIPTION
Added 'install' option useful to copy oibc into /usr/bin with right modes
